### PR TITLE
Add: Per-room notification settings

### DIFF
--- a/matrix-client-handlers.el
+++ b/matrix-client-handlers.el
@@ -264,7 +264,7 @@ like."
 
        ;; Notification
        (unless (equal own-user-id sender)
-         (matrix-client-notify "m.room.message" data :room room))))))
+         (matrix-client-notify room "m.room.message" data))))))
 
 (defun insert-read-only (text &rest extra-props)
   ;; NOTE: The "m.lightrix.pattern" handler is the only one that uses this now.


### PR DESCRIPTION
This may or may not have been motivated by a mini-flame-war in the #emacs:matrix.org channel.  ;)

Seems to be working well for me.  Please let me know what you think, especially regarding the saving of the setting with the `customize` API.

In the future we might want to generalize room-specific settings, but until then, I think this will work well.

I couldn't think of a good, unreserved keybinding (see `info:elisp#Key Binding Conventions`) for the toggle command, so I left it unbound.