### PR TITLE
Fix wrong esxml require symbol

### DIFF
--- a/matrix-client-room.el
+++ b/matrix-client-room.el
@@ -2,7 +2,7 @@
 
 (require 'ordered-buffer)
 
-(require 'esxml)
+(require 'esxml-query)
 
 ;;;; Variables
 


### PR DESCRIPTION
Per discussion on matrix, the symbol needed from esxml is `esxml-query` not `esxml`.