### PR TITLE
Add: Simple notification rules

### DIFF
--- a/matrix-client-room.el
+++ b/matrix-client-room.el
@@ -627,6 +627,10 @@ Also update prompt with typers."
     ;; FIXME: Remove these or update them.
     ;; (set (make-local-variable 'matrix-client-room-connection) con)
     (setq-local matrix-client-room room)
+    ;; Load notification settings for room
+    (with-slots (id client-data) room
+      (when-let* ((rules (a-get matrix-client-room-notification-rules id)))
+        (oset client-data notification-rules rules)))
     ;; Drag-and-drop support
     (setq-local dnd-protocol-alist
                 ;; Support dropping URLs, e.g. from Dolphin or Firefox.  Copied from `dnd-protocol-alist'.

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -50,33 +50,6 @@
 (require 'matrix-notifications)
 (require 'matrix-client-images)
 
-;;;; TEMP
-
-(cl-defun matrix-client-notify-m.room.message (event &key room &allow-other-keys)
-  "Show notification for m.room.message events.
-EVENT should be the `event' variable from the
-`defmatrix-client-handler'.  ROOM should be the room object."
-  (pcase-let* (((map content sender event_id) event)
-               ((map body) content)
-               ((eieio client-data) room)
-               ((eieio buffer) client-data)
-               (display-name (matrix-user-displayname room sender))
-               (id (notifications-notify :title (format$ "<b>$display-name</b>")
-                                         ;; Encode the message as ASCII because dbus-notify
-                                         ;; can't handle some Unicode chars.  And
-                                         ;; `ignore-errors' doesn't work to ignore errors
-                                         ;; from it.  Don't ask me why.
-                                         :body (encode-coding-string body 'us-ascii)
-                                         :category "im.received"
-                                         :timeout 5000
-                                         :app-icon nil
-                                         :actions '("default" "Show")
-                                         :on-action #'matrix-client-notification-show)))
-    (map-put matrix-client-notifications-ring id (a-list 'buffer buffer
-                                                         'event_id event_id))
-    ;; Trim the list
-    (setq matrix-client-notifications-ring (-take 20 matrix-client-notifications-ring))))
-
 ;;;; Variables
 
 (defvar matrix-client-sessions nil


### PR DESCRIPTION
Use the /notify command in a room to change the notification setting for that room.

This does not interact with the Matrix API's push rules.  It's just a simple, local implementation.