### PR TITLE
fix room headers in case of direct chat and/or no topic

### DIFF
--- a/matrix-client-room.el
+++ b/matrix-client-room.el
@@ -684,7 +684,6 @@ Also update prompt with typers."
       (pcase-let* (((eieio avatar typers name topic session) room)
                    ((eieio user) session)
                    (name (propertize (or name display-name) 'face 'font-lock-keyword-face))
-                   (topic (or topic ""))
                    (ov (car (ov-in 'matrix-client-prompt)))
                    (typers-string (s-join ", " (cl-loop for typer across typers
                                                         unless (string= user typer)

--- a/matrix-client-room.el
+++ b/matrix-client-room.el
@@ -683,8 +683,8 @@ Also update prompt with typers."
     (with-room-buffer room
       (pcase-let* (((eieio avatar typers name topic session) room)
                    ((eieio user) session)
-                   (name (when name
-                           (propertize name 'face 'font-lock-keyword-face)))
+                   (name (propertize (or name display-name) 'face 'font-lock-keyword-face))
+                   (topic (or topic ""))
                    (ov (car (ov-in 'matrix-client-prompt)))
                    (typers-string (s-join ", " (cl-loop for typer across typers
                                                         unless (string= user typer)


### PR DESCRIPTION
the room header for direct chats is displayed as nil: nil and for rooms that have no topic it's displayed as {room name}: nil. this PR fixes that by displaying the display-name if room has no name and displaying empty string after the colon in case of no topic.